### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Muddle
-        uses: demonnic/build-with-muddler@v1.3
+        uses: demonnic/build-with-muddler@main
+        with:
+          muddlerVersion: "LATEST"
 
       - name: Upload MPackage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: poopDeck
           path: build/tmp/


### PR DESCRIPTION
It's getting deprecated in January, just staying ahead of versioning.